### PR TITLE
refactor(example): make SimpleScreen work without extra dependencies

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -18,6 +18,9 @@ import { useLayoutEffect } from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MenuView } from '@react-native-menu/menu';
 import { SimpleScreen } from './SimpleScreen';
+import { ThemePreference } from '@vonovak/react-native-theme-control';
+// @ts-ignore
+import SegmentedControl from '@react-native-segmented-control/segmented-control/js/SegmentedControl.js';
 
 type RootStackParamList = {
   Home: undefined;
@@ -134,7 +137,22 @@ function AppStack() {
     <Stack.Navigator>
       <Stack.Screen name="Home" component={ScreenOne} />
       <Stack.Screen name="ScreenTwo" component={ScreenTwo} />
-      <Stack.Screen name="SimpleScreen" component={SimpleScreen} />
+      <Stack.Screen name="SimpleScreen">
+        {() => (
+          <SimpleScreen
+            renderThemePicker={({ values, selected, onSelect }) => (
+              <SegmentedControl
+                style={{ width: '100%' }}
+                values={values}
+                selectedIndex={values.indexOf(selected)}
+                onChange={({ nativeEvent }: { nativeEvent: any }) => {
+                  onSelect(nativeEvent.value as ThemePreference);
+                }}
+              />
+            )}
+          />
+        )}
+      </Stack.Screen>
     </Stack.Navigator>
   );
 }

--- a/example/src/SimpleScreen.tsx
+++ b/example/src/SimpleScreen.tsx
@@ -1,16 +1,32 @@
 import * as React from 'react';
 
-import { Text, useColorScheme, View } from 'react-native';
+import { Button, Text, useColorScheme, View } from 'react-native';
 import {
   setThemePreference,
   SystemBars,
   ThemePreference,
   useThemePreference,
 } from '@vonovak/react-native-theme-control';
-// @ts-ignore
-import SegmentedControl from '@react-native-segmented-control/segmented-control/js/SegmentedControl.js';
 
-export function SimpleScreen() {
+const themePreferences: Array<ThemePreference> = ['light', 'dark', 'system'];
+
+export type ThemePickerProps = {
+  values: Array<ThemePreference>;
+  selected: ThemePreference;
+  onSelect: (value: ThemePreference) => void;
+};
+
+export type SimpleScreenProps = {
+  /**
+   * Render the theme picker. Defaults to plain react-native buttons, so this
+   * screen works in an app that installs nothing but this library. The Expo SDK
+   * compatibility workflow copies this file into a blank app and uses that
+   * default; the example app passes a native segmented control instead.
+   */
+  renderThemePicker?: (props: ThemePickerProps) => React.ReactNode;
+};
+
+export function SimpleScreen({ renderThemePicker }: SimpleScreenProps) {
   const colorScheme = useColorScheme();
   const isDarkMode = colorScheme === 'dark';
   const themePreference = useThemePreference();
@@ -21,7 +37,11 @@ export function SimpleScreen() {
 
   const textColorStyle = { color: textColor };
 
-  const values: Array<ThemePreference> = ['light', 'dark', 'system'];
+  const pickerProps: ThemePickerProps = {
+    values: themePreferences,
+    selected: themePreference,
+    onSelect: setThemePreference,
+  };
 
   return (
     <View
@@ -37,14 +57,11 @@ export function SimpleScreen() {
         backgroundColor={barsBackground}
         dividerColor={dividerColor}
       />
-      <SegmentedControl
-        style={{ width: '100%' }}
-        values={values}
-        selectedIndex={values.indexOf(themePreference)}
-        onChange={({ nativeEvent }: { nativeEvent: any }) => {
-          setThemePreference(nativeEvent.value as ThemePreference);
-        }}
-      />
+      {renderThemePicker ? (
+        renderThemePicker(pickerProps)
+      ) : (
+        <ThemeButtons {...pickerProps} />
+      )}
       <Text style={textColorStyle}>useColorScheme(): {colorScheme}</Text>
       <Text style={textColorStyle}>
         useThemePreference(): {themePreference}
@@ -52,3 +69,19 @@ export function SimpleScreen() {
     </View>
   );
 }
+
+function ThemeButtons({ values, selected, onSelect }: ThemePickerProps) {
+  return (
+    <View style={{ flexDirection: 'row' }}>
+      {values.map((value) => (
+        <Button
+          key={value}
+          title={value === selected ? `[ ${value} ]` : value}
+          onPress={() => onSelect(value)}
+        />
+      ))}
+    </View>
+  );
+}
+
+export default SimpleScreen;


### PR DESCRIPTION
## Why

`SimpleScreen` imported `@react-native-segmented-control/segmented-control` directly, so the screen could only render in an app that installs it.

## What

The picker now arrives through a `renderThemePicker` prop and falls back to plain react-native buttons:

```tsx
export type SimpleScreenProps = {
  renderThemePicker?: (props: ThemePickerProps) => React.ReactNode;
};
```

- The example app passes the native segmented control, so it looks and behaves as before.
- The screen also default-exports, so it can serve as an app entry point.

A blank Expo app can now render it with nothing installed but this library.

## Why it matters

This unblocks the Expo SDK compatibility workflow in #55, which copies this screen into a generated blank app. Without this, that workflow needed its own throwaway `App.tsx` that no developer would ever open, and nothing would catch it drifting from the real API.

This PR stands alone and can merge on its own. #55 contains the same two commits and will collapse once this lands.

## Verified

`yarn typescript`, `yarn lint` and `yarn test` all pass on this branch alone.